### PR TITLE
Feature/coupling demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Description of Variables
 **P_ID**
 Identifier of the different products/articles.
 
+**C_ID**
+Identifier of the different coupling products/articles.
+
 **L_ID**
 Identifier of the different locations/stores.
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@ Description of Variables
 **P_ID**
 Identifier of the different products/articles.
 
-**C_ID**
-Identifier of the different coupling products/articles.
-
 **L_ID**
 Identifier of the different locations/stores.
 

--- a/optional_demand.py
+++ b/optional_demand.py
@@ -22,9 +22,9 @@ def balance(
         series with rough balansed log lambda
     """
 
-
-    _max = s.max()
-    s = s.apply(lambda x : x + (abs(_max - x) * gain))
+    if -1 not in s['C_ID']:
+        _max = s['LOG_LAMBDA'].max()
+        s['LOG_LAMBDA'] = s['LOG_LAMBDA'].apply(lambda x : x + (abs(_max - x) * gain))
     
     return s
 
@@ -72,6 +72,6 @@ def simulate_coupling_demand(
     df['C_ID'] = pd.Series([couple_map[x] for x in df['P_ID']])
 
     # add coupling demand effect
-    df['LOG_LAMBDA'] = df.groupby(["C_ID", "L_ID"], group_keys=False)["LOG_LAMBDA"].apply(balance, 0.5)
+    df['LOG_LAMBDA'] = df.groupby(["C_ID", "L_ID"], group_keys=False).apply(balance, 0.5)['LOG_LAMBDA']
 
     return df

--- a/optional_demand.py
+++ b/optional_demand.py
@@ -62,7 +62,7 @@ def simulate_coupling_demand(
         df.loc[mask, 'C_ID'] = c_id
         p_id = list(set(p_id) - set(couple)) # not allow overlapping
 
-    # add coupling demand effect anly cou
+    # add coupling demand effect for couple 
     df[df['C_ID'] != -1]['LOG_LAMBDA'] = df.groupby(["C_ID", "L_ID"],
                                    group_keys=False)['LOG_LAMBDA'].apply(
                                    balance, np.random.uniform(0.0, 0.5))

--- a/optional_demand.py
+++ b/optional_demand.py
@@ -72,6 +72,8 @@ def simulate_coupling_demand(
     df['C_ID'] = pd.Series([couple_map[x] for x in df['P_ID']])
 
     # add coupling demand effect
-    df['LOG_LAMBDA'] = df.groupby(["C_ID", "L_ID"], group_keys=False).apply(balance, 0.5)['LOG_LAMBDA']
+    df['LOG_LAMBDA'] = df.groupby(["C_ID", "L_ID"],
+                                   group_keys=False).apply(
+                                   balance, np.random.uniform(0.0, 0.5))['LOG_LAMBDA']
 
     return df

--- a/optional_demand.py
+++ b/optional_demand.py
@@ -23,7 +23,7 @@ def balance(
     """
 
     _max = s.max()
-    s = s.apply(lambda x : x + ((_max - x) * gain))
+    s = s + (_max - s) * gain
     
     return s
 

--- a/optional_demand.py
+++ b/optional_demand.py
@@ -62,8 +62,9 @@ def simulate_coupling_demand(
         df.loc[mask, 'C_ID'] = c_id
         p_id = list(set(p_id) - set(couple)) # not allow overlapping
 
-    # add coupling demand effect for couple 
-    df[df['C_ID'] != -1]['LOG_LAMBDA'] = df.groupby(["C_ID", "L_ID"],
+    # add coupling demand effect for couple
+    mask = df['C_ID'] != -1
+    df.loc[mask, 'LOG_LAMBDA'] = df.loc[mask].groupby(["C_ID", "L_ID"],
                                    group_keys=False)['LOG_LAMBDA'].apply(
                                    balance, np.random.uniform(0.0, 0.5))
 

--- a/optional_demand.py
+++ b/optional_demand.py
@@ -1,0 +1,77 @@
+import numpy as np
+import pandas as pd
+
+
+def balance(
+    s: pd.Series,
+    gain: float = 0.5,
+) -> pd.Series:
+    """
+    calulate rough balansed log lambda. 
+    because coupled product demand seems to be similar.
+
+    Parameters
+    ----------
+    s
+        series
+    gain
+        demand increase ratio to lower demand products in a couple
+
+    Returns
+    -------
+        series with rough balansed log lambda
+    """
+
+
+    _max = s.max()
+    s = s.apply(lambda x : x + (abs(_max - x) * gain))
+    
+    return s
+
+
+def simulate_coupling_demand(
+    df: pd.DataFrame,
+    n_couples: int,
+    max_products: int = 3,
+) -> pd.DataFrame:
+    """
+    Simulates coupling demand.
+    In many cases, Bread and Jam are usually bought same time.
+
+    Parameters
+    ----------
+    df
+        dataframe
+    n_couples
+        number of couples to simulate
+    max_products
+        max number of products included in one-couple
+
+    Returns
+    -------
+        dataframe with added ``C_ID`` and coupling demand effect added on the log lambda column.
+        if C_ID is -1, it means no coupled products.
+    """
+
+    couple_map = {}
+    p_id = df['P_ID'].unique()
+
+    # couple
+    for c_id in range(n_couples):
+        prods = np.random.randint(low=2, high=max_products+1)
+        couple = np.random.choice(p_id, size=prods, replace=False)
+        for c in couple:
+            couple_map[c] = c_id
+        p_id = list(set(p_id) - set(couple)) # not allow overlapping
+
+    # not couple
+    for c in p_id:
+        couple_map[c] = -1
+
+    # add couple id as column
+    df['C_ID'] = pd.Series([couple_map[x] for x in df['P_ID']])
+
+    # add coupling demand effect
+    df['LOG_LAMBDA'] = df.groupby(["C_ID", "L_ID"], group_keys=False)["LOG_LAMBDA"].apply(balance, 0.5)
+
+    return df

--- a/simulations.py
+++ b/simulations.py
@@ -14,6 +14,8 @@ from base_demand import \
     simulate_locations, \
     simulate_dates, \
     simulate_basic_demand
+from optional_demand import \
+    simulate_coupling_demand
 from seasonalities import \
     simulate_trend,\
     simulate_weekday_profile, \
@@ -69,6 +71,8 @@ def main(args):
     )
 
     df = simulate_basic_demand(df)
+
+    df = simulate_coupling_demand(df, n_couples=20, max_products=3)
 
     df = simulate_trend(df)
 


### PR DESCRIPTION
# Pull Request
<!-- Pull Requestのタイトル -->
Coupling demand effect simulation
## Ticket
<!-- チケットがあればリンク貼る -->
None

## PR type
<!-- Pull Requestの種類を選択 -->
<!-- 必要なものだけ残す -->
* 🆕New feature
<!-- * 🐛Bug fix -->
<!--* 🧹Refuctaring -->
* 📖Document update
<!--* 💻Development environment -->
<!--* 🚄Infrastructure -->
<!--* ✅Test -->

## Overview
<!-- Pull Request 概要・背景など -->
Add a new function that simulates the coupling demand effect. For example, it's something like that Bread and Jam are bought together in many cases.

## Update points
<!-- 変更点 -->
Created a new script optional_demand.py and added some code in the simulation.py

## Affected part
<!-- 影響範囲 -->
simulation.py

## Test
<!-- テスト手順 -->
Verified to run the simulation correctly with the command "python simulation.py"
<!-- テスト結果 -->
the simulation have done correctly
## Other comments
<!-- レビュワーへの注意点・相談内容・懸念点 -->
I have no confidence in the coupling demand simulation logic, thus please check it. I implemented the demand for each product in the same couple (e.x. Bread and Jam) to be slightly similar.